### PR TITLE
feat: setup sockets for private chat with docs and sequence diagram

### DIFF
--- a/backend/config/swagger/index.js
+++ b/backend/config/swagger/index.js
@@ -1,0 +1,25 @@
+/**
+ * Swagger Configuration Index
+ * Centralized exports for all Swagger configurations
+ */
+
+const { generateMainApiSpec } = require('./mainApi');
+const { generatePublicApiSpec } = require('./publicApi');
+
+/**
+ * Generate all Swagger specifications
+ * @param {number} PORT - Server port number
+ * @returns {Object} Object containing all Swagger specs
+ */
+const generateAllSwaggerSpecs = (PORT) => {
+  return {
+    mainApi: generateMainApiSpec(PORT),
+    publicApi: generatePublicApiSpec(PORT)
+  };
+};
+
+module.exports = {
+  generateAllSwaggerSpecs,
+  generateMainApiSpec,
+  generatePublicApiSpec
+};

--- a/backend/config/swagger/mainApi.js
+++ b/backend/config/swagger/mainApi.js
@@ -1,0 +1,57 @@
+/**
+ * Main API Swagger Configuration
+ * Contains configuration for authenticated endpoints and core functionality
+ */
+
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const createMainApiSwaggerConfig = (PORT) => {
+  return {
+    definition: {
+      openapi: '3.0.0',
+      info: {
+        title: 'SDP Project API',
+        version: '1.0.0',
+        description: 'Backend API for SDP Project',
+        contact: {
+          name: 'API Support',
+          email: 'support@example.com'
+        }
+      },
+      servers: [
+        {
+          url: `http://localhost:${PORT}`,
+          description: 'Development server'
+        },
+        {
+          url: 'https://your-production-domain.com1',
+          description: 'Production server'
+        },
+        {
+          url: `ws://localhost:${PORT}${(process.env.API_PREFIX||'/api/v1').replace(/\/$/, '')}/sockets`,
+          description: 'WebSocket (Socket.IO namespace with API prefix)'
+        }
+      ],
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'JWT'
+          }
+        }
+      }
+    },
+    apis: ['./routes/*.js', './models/*.js', './sockets/*.js']
+  };
+};
+
+const generateMainApiSpec = (PORT) => {
+  const options = createMainApiSwaggerConfig(PORT);
+  return swaggerJsdoc(options);
+};
+
+module.exports = {
+  createMainApiSwaggerConfig,
+  generateMainApiSpec
+};

--- a/backend/config/swagger/publicApi.js
+++ b/backend/config/swagger/publicApi.js
@@ -1,0 +1,153 @@
+/**
+ * Public Resources API Swagger Configuration
+ * Contains configuration for public, unauthenticated endpoints
+ */
+
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const createPublicApiSwaggerConfig = (PORT) => {
+  return {
+    definition: {
+      openapi: '3.0.0',
+      info: {
+        title: 'Studdy Buddy - Public Resources API',
+        version: '1.0.0',
+        description: `
+# Public Resources API Documentation
+
+This API provides endpoints for managing public resources associated with events. These endpoints are designed to be publicly accessible and do not require authentication.
+
+## 🚀 Features
+- **No Authentication Required**: All endpoints are publicly accessible
+- **File Upload Support**: Upload images (JPG, PNG, GIF, WebP) and PDF documents
+- **Cloud Storage**: Automatic file storage and optimization via Cloudinary
+- **Event Association**: Resources are linked to specific events via event_id
+
+## 📋 Available Operations
+- **GET**: Retrieve public resources by event ID
+- **POST**: Upload multiple pictures or PDF documents
+- **DELETE**: Remove pictures or PDF documents for an event
+
+## 📝 Important Notes
+- All file uploads are automatically optimized
+- Files are stored securely in Cloudinary
+- maximum of 10 pictures can be uploaded at a time
+- maximum of 1 PDF can be uploaded at a time
+- maximum of 5MB per picture
+- maximum of 5MB per PDF
+- Event IDs must be valid strings
+        `,
+        contact: {
+          name: 'API Support',
+          email: 'support@example.com'
+        },
+        license: {
+          name: 'MIT',
+          url: 'https://opensource.org/licenses/MIT'
+        }
+      },
+      servers: [
+        {
+          url: `http://localhost:${PORT}`,
+          description: 'Development server'
+        },
+        {
+          url: 'https://https://sdp-project-zilb.onrender.com',
+          description: 'Production server'
+        }
+      ],
+      components: {
+        schemas: {
+          PublicResource: {
+            type: 'object',
+            required: ['id', 'event_id', 'created_at'],
+            properties: {
+              id: {
+                type: 'string',
+                format: 'uuid',
+                description: 'Unique identifier for the public resource',
+                example: '550e8400-e29b-41d4-a716-446655440000'
+              },
+              file_url: {
+                type: 'string',
+                description: 'URL of the uploaded PDF file',
+                example: 'https://res.cloudinary.com/demo/image/upload/v1234567890/sdp-project/public/event123/document.pdf'
+              },
+              public_id: {
+                type: 'string',
+                description: 'Cloudinary public ID for the resource',
+                example: 'sdp-project/public/event123/document'
+              },
+              picture_url: {
+                type: 'string',
+                description: 'URL of the uploaded image file',
+                example: 'https://res.cloudinary.com/demo/image/upload/v1234567890/sdp-project/public/event123/image.jpg'
+              },
+              event_id: {
+                type: 'string',
+                description: 'ID of the associated event (can be any string identifier)',
+                example: 'event-12345'
+              },
+              created_at: {
+                type: 'string',
+                format: 'date-time',
+                description: 'Timestamp when the resource was created',
+                example: '2024-01-15T10:30:00Z'
+              }
+            }
+          },
+          ApiResponse: {
+            type: 'object',
+            properties: {
+              success: {
+                type: 'boolean',
+                description: 'Indicates if the request was successful'
+              },
+              data: {
+                type: 'object',
+                description: 'Response data (when success is true)'
+              },
+              message: {
+                type: 'string',
+                description: 'Success message (when success is true)'
+              },
+              error: {
+                type: 'string',
+                description: 'Error message (when success is false)'
+              }
+            }
+          }
+        },
+        parameters: {
+          EventIdPath: {
+            in: 'path',
+            name: 'event_id',
+            required: true,
+            schema: {
+              type: 'string'
+            },
+            description: 'Unique identifier of the event (can be any string)',
+            example: 'event-12345'
+          }
+        }
+      },
+      tags: [
+        {
+          name: 'Public Resources',
+          description: 'Public resource management endpoints for events. These endpoints do not require authentication and are designed for public access.'
+        }
+      ]
+    },
+    apis: ['./routes/PublicApi.js'] // Only include PublicApi routes
+  };
+};
+
+const generatePublicApiSpec = (PORT) => {
+  const options = createPublicApiSwaggerConfig(PORT);
+  return swaggerJsdoc(options);
+};
+
+module.exports = {
+  createPublicApiSwaggerConfig,
+  generatePublicApiSpec
+};

--- a/backend/config/swagger/uiConfig.js
+++ b/backend/config/swagger/uiConfig.js
@@ -1,0 +1,67 @@
+/**
+ * Swagger UI Configuration
+ * Contains custom styling and setup options for Swagger UI
+ */
+
+const swaggerUi = require('swagger-ui-express');
+
+/**
+ * Custom CSS for Public Resources API documentation
+ */
+const publicApiCustomCSS = `
+  .swagger-ui .topbar { display: none; }
+  .swagger-ui .info .title { color: #3b82f6; font-size: 2.5rem; margin-bottom: 1rem; }
+  .swagger-ui .info .description { font-size: 1.1rem; line-height: 1.6; margin-bottom: 2rem; }
+  .swagger-ui .scheme-container { background: #f8fafc; padding: 1rem; border-radius: 8px; margin: 1rem 0; }
+  .swagger-ui .opblock.opblock-get { border-color: #3b82f6; background: rgba(59, 130, 246, 0.1); }
+  .swagger-ui .opblock.opblock-post { border-color: #10b981; background: rgba(16, 185, 129, 0.1); }
+  .swagger-ui .opblock.opblock-delete { border-color: #ef4444; background: rgba(239, 68, 68, 0.1); }
+  .swagger-ui .opblock-summary-description { font-weight: 500; }
+`;
+
+/**
+ * Setup options for Public Resources API documentation
+ */
+const publicApiSetupOptions = {
+  customCss: publicApiCustomCSS,
+  customSiteTitle: 'Public Resources API Documentation'
+};
+
+/**
+ * Setup options for Main API documentation
+ */
+const mainApiSetupOptions = {
+  customSiteTitle: 'SDP Project API Documentation'
+};
+
+/**
+ * Create Swagger UI middleware for main API
+ * @param {Object} swaggerSpec - Swagger specification object
+ * @returns {Array} Express middleware array
+ */
+const createMainApiSwaggerUI = (swaggerSpec) => {
+  return [
+    swaggerUi.serveFiles(swaggerSpec, {}),
+    swaggerUi.setup(swaggerSpec, mainApiSetupOptions)
+  ];
+};
+
+/**
+ * Create Swagger UI middleware for Public Resources API
+ * @param {Object} swaggerSpec - Swagger specification object
+ * @returns {Array} Express middleware array
+ */
+const createPublicApiSwaggerUI = (swaggerSpec) => {
+  return [
+    swaggerUi.serveFiles(swaggerSpec, {}),
+    swaggerUi.setup(swaggerSpec, publicApiSetupOptions)
+  ];
+};
+
+module.exports = {
+  createMainApiSwaggerUI,
+  createPublicApiSwaggerUI,
+  publicApiSetupOptions,
+  mainApiSetupOptions,
+  publicApiCustomCSS
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -22,6 +22,7 @@ const Progress = require('./Progress');
 const Study_groups = require('./Study_groups');
 const Study_sessions = require('./Study_sessions');
 const Follows_requests = require('./follows_requests');
+const public_resources = require('./public_resources');
 
 
 // Define associations
@@ -111,5 +112,6 @@ module.exports = {
   Progress,
   Study_groups,
   Study_sessions,
-  Likes
+  Likes,
+  public_resources
 };

--- a/backend/models/public_resources.js
+++ b/backend/models/public_resources.js
@@ -1,0 +1,36 @@
+const { DataTypes } = require('sequelize'); 
+const { sequelize } = require('../config/database');
+
+const public_resources = sequelize.define('public_resources', {
+    id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        defaultValue: DataTypes.UUIDV4
+    },
+    file_url: {
+        type: DataTypes.STRING,
+        allowNull: true
+    },
+    public_id: {
+        type: DataTypes.STRING,
+        allowNull: false
+    },
+    picture_url: {
+        type: DataTypes.STRING,
+        allowNull: true
+    },
+    event_id: {
+        type: DataTypes.STRING,
+        allowNull: false
+    },
+    created_at: {
+        type: DataTypes.DATE,
+        allowNull: false
+    },
+    updated_at: {
+        type: DataTypes.DATE,
+        allowNull: true
+    }
+});
+
+module.exports = public_resources;

--- a/backend/routes/PublicApi.js
+++ b/backend/routes/PublicApi.js
@@ -1,21 +1,453 @@
 const express = require('express');
 const router = express.Router();
-const { Courses } = require('../models');
+ 
+const { public_resources } = require('../models');
 const { Op } = require('sequelize');
-
+const CloudinaryService = require('../services/cloudinaryService');
+const { uploadSingle, handleUploadError, uploadMultiple } = require('../middleware/upload');
 
 /**
  * @swagger
- * /api/v1/public/courses:
- *   get:
- *     summary: Get all courses
- *     tags: [Public]
+ * components:
+ *   schemas:
+ *     UploadResponse:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *           example: true
+ *         message:
+ *           type: string
+ *           example: "Pictures uploaded successfully"
+ *     
+ *     ErrorResponse:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *           example: false
+ *         error:
+ *           type: string
+ *           example: "Resource not found"
  */
-router.get('/courses', async (req, res) => {
-  const courses = await Courses.findAll({ where: { approved: true } });
-  res.json({
-    success: true,
-    data: courses
-  });
+
+/**
+ * @swagger
+ * tags:
+ *   name: Public Resources
+ *   description: Public resource management endpoints for events
+ */
+
+/**
+ * @swagger
+ * /api/v1/public/{event_id}:
+ *   get:
+ *     summary: Get public resource by event ID
+ *     description: Retrieve a public resource associated with a specific event. This endpoint does not require authentication and is publicly accessible.
+ *     tags: [Public Resources]
+ *     parameters:
+ *       - $ref: '#/components/parameters/EventIdPath'
+ *     responses:
+ *       200:
+ *         description: Public resource retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/PublicResource'
+ *             examples:
+ *               success:
+ *                 summary: Successful retrieval
+ *                 value:
+ *                   success: true
+ *                   data:
+ *                     id: "550e8400-e29b-41d4-a716-446655440000"
+ *                     file_url: "https://res.cloudinary.com/demo/image/upload/v1234567890/sdp-project/public/event123/document.pdf"
+ *                     public_id: "sdp-project/public/event123/document"
+ *                     picture_url: "https://res.cloudinary.com/demo/image/upload/v1234567890/sdp-project/public/event123/image.jpg"
+ *                     event_id: "550e8400-e29b-41d4-a716-446655440001"
+ *                     created_at: "2024-01-15T10:30:00Z"
+ *       404:
+ *         description: Resource not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               not_found:
+ *                 summary: Resource not found
+ *                 value:
+ *                   success: false
+ *                   error: "resource not found"
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               server_error:
+ *                 summary: Server error
+ *                 value:
+ *                   success: false
+ *                   error: "Internal server error"
+ *     security: []
+ */
+router.get('/:event_id', async (req, res) => {
+    const { event_id } = req.params;
+    try {
+      const exist = await public_resources.findOne({ where: { event_id: event_id } });
+      if (!exist) {
+        return res.status(404).json({ success: false, error: 'resource not found' });
+      }
+        const publicResource = await public_resources.findOne({ where: { event_id: event_id } });
+        res.json({ success: true, data: publicResource });
+    } catch (error) {
+        console.error('Error retrieving public resource:', error);
+        res.status(500).json({ success: false, error: 'Internal server error' });
+    }
+    
+   
 });
+
+/**
+ * @swagger
+ * /api/v1/public/pictures:
+ *   post:
+ *     summary: Upload multiple pictures for an event
+ *     description: Upload one or more image files for a public event. Images are automatically optimized and stored in Cloudinary. This endpoint does not require authentication and is publicly accessible.
+ *     tags: [Public Resources]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - files
+ *               - event_id
+ *             properties:
+ *               files:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: binary
+ *                 description: One or more image files to upload (jpg, jpeg, png, gif, webp)
+ *                 minItems: 1
+ *                 maxItems: 10
+ *               event_id:
+ *                 type: string
+ *                 description: ID of the event to associate the pictures with (can be any string)
+ *                 example: "event-12345"
+ *           encoding:
+ *             files:
+ *               contentType: image/*
+ *     responses:
+ *       200:
+ *         description: Pictures uploaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UploadResponse'
+ *             examples:
+ *               success:
+ *                 summary: Upload successful
+ *                 value:
+ *                   success: true
+ *                   message: "Pictures uploaded successfully"
+ *       400:
+ *         description: Bad request - No image files provided
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               no_files:
+ *                 summary: No files provided
+ *                 value:
+ *                   success: false
+ *                   error: "No image file provided"
+ *       500:
+ *         description: Internal server error during upload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               upload_error:
+ *                 summary: Upload failed
+ *                 value:
+ *                   success: false
+ *                   error: "Internal server error"
+ *     security: []
+ */
+router.post('/pictures', uploadMultiple, handleUploadError, async (req, res) => {
+    const {event_id } = req.body;
+try{
+    if (!req.files) {
+      return res.status(400).json({
+        success: false,
+        error: 'No image file provided'
+      });
+    }
+    
+
+    const uploadResult = await CloudinaryService.uploadImage(req.files.map(file => file.buffer), {
+        folder: `sdp-project/public/${event_id}`,
+      resource_type: 'image',
+      allowed_formats: ['jpg', 'jpeg', 'png', 'gif', 'webp'],
+      transformation: [
+        { quality: 'auto' },
+        { fetch_format: 'auto' }
+      ],
+      ...req.files.map(file => ({
+        picture_url: file.secure_url,
+        public_id: file.public_id,
+        event_id: event_id,
+        created_at: new Date()
+      })),
+    });
+    await public_resources.create({
+       picture_url: uploadResult.secure_url,
+        public_id: uploadResult.public_id,
+         event_id: event_id,
+         created_at: new Date()
+        });
+    res.json({ success: true, message: 'Pictures uploaded successfully' });
+} catch (error) {
+    console.error('Error uploading pictures:', error);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+}
+});
+
+/**
+ * @swagger
+ * /api/v1/public/pdf:
+ *   post:
+ *     summary: Upload a PDF document for an event
+ *     description: Upload a single PDF file for a public event. The PDF is stored in Cloudinary for secure access. This endpoint does not require authentication and is publicly accessible.
+ *     tags: [Public Resources]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - file
+ *               - event_id
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *                 description: PDF file to upload (max size and format restrictions apply)
+ *               event_id:
+ *                 type: string
+ *                 description: ID of the event to associate the PDF with (can be any string)
+ *                 example: "event-12345"
+ *           encoding:
+ *             file:
+ *               contentType: application/pdf
+ *     responses:
+ *       200:
+ *         description: PDF uploaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UploadResponse'
+ *             examples:
+ *               success:
+ *                 summary: Upload successful
+ *                 value:
+ *                   success: true
+ *                   message: "PDF uploaded successfully"
+ *       400:
+ *         description: Bad request - No PDF file provided
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               no_file:
+ *                 summary: No file provided
+ *                 value:
+ *                   success: false
+ *                   error: "No PDF file provided"
+ *       500:
+ *         description: Internal server error during upload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               upload_error:
+ *                 summary: Upload failed
+ *                 value:
+ *                   success: false
+ *                   error: "Internal server error"
+ *     security: []
+ */
+router.post('/pdf', uploadSingle, handleUploadError, async (req, res) => {
+    const {event_id } = req.body;
+try{
+    if (!req.file) {
+      return res.status(400).json({
+        success: false,
+        error: 'No PDF file provided'
+      });
+    }
+
+    const uploadResult = await CloudinaryService.uploadPDF(req.file.buffer, {
+        folder: `sdp-project/public/${event_id}`,
+      });
+    await public_resources.create({
+       file_url: uploadResult.secure_url,
+        public_id: uploadResult.public_id,
+         event_id: event_id,
+         created_at: new Date()
+        });
+    res.json({ success: true, message: 'PDF uploaded successfully' });
+} catch (error) {
+    console.error('Error uploading PDF:', error);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+}
+});
+
+/**
+ * @swagger
+ * /api/v1/public/pdf/{event_id}:
+ *   delete:
+ *     summary: Delete PDF document for an event
+ *     description: Delete a PDF document associated with a specific event. The file is removed from both the database and Cloudinary storage. This endpoint does not require authentication and is publicly accessible.
+ *     tags: [Public Resources]
+ *     parameters:
+ *       - $ref: '#/components/parameters/EventIdPath'
+ *     responses:
+ *       200:
+ *         description: PDF deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UploadResponse'
+ *             examples:
+ *               success:
+ *                 summary: Deletion successful
+ *                 value:
+ *                   success: true
+ *                   message: "PDF deleted successfully"
+ *       404:
+ *         description: Public resource not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               not_found:
+ *                 summary: Resource not found
+ *                 value:
+ *                   success: false
+ *                   error: "Public resource not found"
+ *       500:
+ *         description: Internal server error during deletion
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               delete_error:
+ *                 summary: Deletion failed
+ *                 value:
+ *                   success: false
+ *                   error: "Internal server error"
+ *     security: []
+ */
+router.delete('/pdf/:event_id', async (req, res) => {
+    const {event_id } = req.params;
+try{
+    const publicResource = await public_resources.findOne({ where: { event_id: event_id } });
+    if (!publicResource) {
+      return res.status(404).json({ success: false, error: 'Public resource not found' });
+    }
+    if (publicResource.public_id) {
+      await CloudinaryService.deletePDF(publicResource.public_id);
+    }
+    await publicResource.destroy();
+    res.json({ success: true, message: 'PDF deleted successfully' });
+} catch (error) {
+    console.error('Error deleting PDF:', error);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+}
+});
+
+/**
+ * @swagger
+ * /api/v1/public/pictures/{event_id}:
+ *   delete:
+ *     summary: Delete pictures for an event
+ *     description: Delete all pictures associated with a specific event. The images are removed from both the database and Cloudinary storage. This endpoint does not require authentication and is publicly accessible.
+ *     tags: [Public Resources]
+ *     parameters:
+ *       - $ref: '#/components/parameters/EventIdPath'
+ *     responses:
+ *       200:
+ *         description: Pictures deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UploadResponse'
+ *             examples:
+ *               success:
+ *                 summary: Deletion successful
+ *                 value:
+ *                   success: true
+ *                   message: "Pictures deleted successfully"
+ *       404:
+ *         description: Public resource not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               not_found:
+ *                 summary: Resource not found
+ *                 value:
+ *                   success: false
+ *                   error: "Public resource not found"
+ *       500:
+ *         description: Internal server error during deletion
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               delete_error:
+ *                 summary: Deletion failed
+ *                 value:
+ *                   success: false
+ *                   error: "Internal server error"
+ *     security: []
+ */
+router.delete('/pictures/:event_id', async (req, res) => {
+    const {event_id } = req.params;
+try{
+    const publicResource = await public_resources.findOne({ where: { event_id: event_id } });
+    if (!publicResource) {
+      return res.status(404).json({ success: false, error: 'Public resource not found' });
+    } 
+    if(publicResource.public_id) {
+      await CloudinaryService.deleteImage(publicResource.public_id);
+    }
+    await publicResource.destroy();
+    res.json({ success: true, message: 'Pictures deleted successfully' });
+} catch (error) {
+    console.error('Error deleting pictures:', error);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+}
+});
+
+
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -11,9 +11,9 @@ const userCourseRoutes = require('./UserCourses');
 const Study_groupsRoutes = require('./Study_groups')
 const Follows_requests = require('./follows_requests');
 const resourcesRoutes = require('./Resources')
-const publicRoutes = require('./PublicApi');
 const resourcethreadsRoutes = require('./resource_threads');
 const liked_Routes = require('./likes');
+const publicApiRoutes = require('./PublicApi');
 
 
 // API Documentation
@@ -54,7 +54,8 @@ router.get('/', (req, res) => {
       docs: '/api-docs',
       resources: '/resources',
       resource_threads: '/resource_threads',
-      likes: '/likes/:id'
+      likes: '/likes/:id',
+      public: '/public'
 
     }
   });
@@ -70,7 +71,7 @@ router.use('/user-courses', userCourseRoutes);
 router.use('/study_groups',Study_groupsRoutes);
 router.use('/friends',Follows_requests);
 router.use('/resources', resourcesRoutes);
-router.use('/public', publicRoutes);
 router.use('/resource_threads', resourcethreadsRoutes);
 router.use('/likes', liked_Routes);
+router.use('/public', publicApiRoutes);
 module.exports = router; 


### PR DESCRIPTION
- Added and tested sockets for private chat (basic functionality working, but needs further verification).
- Included markdown documentation and a sequence diagram to illustrate frontend communication. 
- Removed authorization requirements in implementation due to issues (still shown in diagram, but can be ignored).
- Kept rest of sequence diagram unchanged.